### PR TITLE
Add workaround for constants in C# scripts

### DIFF
--- a/SkyEditor.RomEditor.Rtdx.Tests/TestData/Scripts/CSharp/RomInteractionTest.csx
+++ b/SkyEditor.RomEditor.Rtdx.Tests/TestData/Scripts/CSharp/RomInteractionTest.csx
@@ -3,11 +3,9 @@
 var starters = Rom.GetStarters().Starters;
 
 var riolu = starters[0];
-if (riolu.PokemonId != SkyEditor.RomEditor.Rtdx.Reverse.Const.creature.Index.RIORU) throw new Exception("Failed to read first starter's PokemonId");
+if (riolu.PokemonId != CreatureIndex.RIORU) throw new Exception("Failed to read first starter's PokemonId");
 if (riolu.PokemonName != "Riolu") throw new Exception("Failed to read first starter's PokemonId");
 
 var mew = starters[1];
-if (mew.PokemonId != SkyEditor.RomEditor.Rtdx.Reverse.Const.creature.Index.MYUU) throw new Exception("Failed to read second starter's PokemonId");
+if (mew.PokemonId != CreatureIndex.MYUU) throw new Exception("Failed to read second starter's PokemonId");
 if (mew.PokemonName != "Mew") throw new Exception("Failed to read second starter's PokemonId");
-
-


### PR DESCRIPTION
Allows using shorter names like `CreatureIndex` in C# scripts