### PR TITLE
Add editing support for pokemon_form_database, dungeon_map_symbol and dungeon_bgm_symbol

### DIFF
--- a/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Queries/Rtdx/PrintSymbolLists.csx
+++ b/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Queries/Rtdx/PrintSymbolLists.csx
@@ -1,0 +1,19 @@
+﻿#load "../../../Stubs/Rtdx.csx"
+
+using System;
+using SkyEditor.RomEditor.Domain.Rtdx.Structures;
+
+void Print(Sir0StringList stringList)
+{
+    for (int i = 0; i < stringList.Entries.Count; i++)
+    {
+        Console.WriteLine($"{i}: {stringList.Entries[i]}");
+    }
+}
+
+Console.WriteLine("-------- DungeonMapSymbol");
+Print(Rom.GetDungeonMapSymbol());
+
+Console.WriteLine("");
+Console.WriteLine("-------- DungeonBgmSymbol");
+Print(Rom.GetDungeonBgmSymbol());

--- a/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Utilities/Rtdx/AddDialogueComments.csx
+++ b/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Utilities/Rtdx/AddDialogueComments.csx
@@ -1,0 +1,44 @@
+// This script adds comments with the english dialogue lines to all Lua scripts used by the game.
+
+#load "../../../Stubs/RTDX.csx"
+
+using System;
+using System.IO;
+using SkyEditor.RomEditor.Domain.Rtdx.Constants;
+using SkyEditor.RomEditor.Domain.Rtdx;
+using SkyEditor.RomEditor.Domain.Rtdx.Structures;
+using System.Text.RegularExpressions;
+
+var usMessageBin = Rom.GetUSMessageBin();
+var scriptStrings = new MessageBinEntry(Rom.GetUSMessageBin().GetFile("script.bin"));
+
+string LuaScriptsPath = Path.Combine(Rom.RomDirectory, "romfs", "Data", "StreamingAssets", "native_data", "script", "event");
+
+foreach (var luaFile in new DirectoryInfo(LuaScriptsPath).GetFiles("*.lua", SearchOption.AllDirectories))
+{
+  string[] lines = File.ReadAllLines(luaFile.FullName);
+  for (int i = 0; i < lines.Length; i++)
+  {
+    string line = lines[i];
+    var match = Regex.Match(line, "TextID\\(\"(?<textIdValue>.+?)\",");
+    if (!match.Success)
+    {
+      continue;
+    }
+
+    string textId = match.Groups["textIdValue"].Value;
+
+    // Story script strings are prefixed with "SCRIPT__"
+    int textIdHash = (int) Farc.PmdHashing.Crc32Hash("SCRIPT__" + textId);
+
+    if (!scriptStrings.Strings.ContainsKey(textIdHash))
+    {
+      continue;
+    }
+
+    string dialogueLine = scriptStrings.Strings[textIdHash].Replace("\n", "\\n");
+    lines[i] = $"{line} -- {dialogueLine}";
+  }
+
+  File.WriteAllLines(luaFile.FullName, lines);
+}

--- a/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Utilities/Rtdx/GenerateTranscript.csx
+++ b/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Utilities/Rtdx/GenerateTranscript.csx
@@ -1,0 +1,66 @@
+// This script generates a text file containing all dialogues.
+// The resulting transcript.txt file will be saved in the current working directory.
+
+#load "../../../Stubs/RTDX.csx"
+
+using System;
+using System.IO;
+using SkyEditor.RomEditor.Domain.Rtdx.Constants;
+using SkyEditor.RomEditor.Domain.Rtdx;
+using SkyEditor.RomEditor.Domain.Rtdx.Structures;
+using System.Text.RegularExpressions;
+using System.Text;
+
+var usMessageBin = Rom.GetUSMessageBin();
+var scriptStrings = new MessageBinEntry(Rom.GetUSMessageBin().GetFile("script.bin"));
+
+string LuaScriptsPath = Path.Combine(Rom.RomDirectory, "romfs", "Data", "StreamingAssets", "native_data", "script", "event");
+
+var transcript = new StringBuilder();
+
+foreach (var luaFile in new DirectoryInfo(LuaScriptsPath).GetFiles("*.lua", SearchOption.AllDirectories))
+{
+  transcript.AppendLine("------");
+  transcript.AppendLine(luaFile.Name);
+  transcript.AppendLine("------");
+
+  string[] lines = File.ReadAllLines(luaFile.FullName);
+  for (int i = 0; i < lines.Length; i++)
+  {
+    string line = lines[i];
+    var textIdMatch = Regex.Match(line, "TextID\\(\"(?<textIdValue>.+?)\",");
+    if (!textIdMatch.Success)
+    {
+      continue;
+    }
+
+    string textId = textIdMatch.Groups["textIdValue"].Value;
+
+    var actorNameMatch = Regex.Match(line, "LuaSymAct\\(\"(?<actorName>.+?)\"");
+
+    string actorName;
+    if (line.ToLower().Contains("monologue"))
+    {
+      actorName = "(monologue)";
+    }
+    else
+    {
+      actorName = actorNameMatch.Success ? actorNameMatch.Groups["actorName"].Value : "";
+    }
+
+    // Story script strings are prefixed with "SCRIPT__"
+    int textIdHash = (int) Farc.PmdHashing.Crc32Hash("SCRIPT__" + textId);
+
+    if (!scriptStrings.Strings.ContainsKey(textIdHash))
+    {
+      continue;
+    }
+
+    string dialogueLine = scriptStrings.Strings[textIdHash].Replace("\n", "\n  ");
+    transcript.AppendLine($"{actorName}: {dialogueLine}");
+  }
+
+  transcript.AppendLine();
+}
+
+File.WriteAllText("transcript.txt", transcript.ToString());

--- a/SkyEditor.RomEditor.Rtdx.Tests/Domain/Structures/PokemonFormDatabaseTests.cs
+++ b/SkyEditor.RomEditor.Rtdx.Tests/Domain/Structures/PokemonFormDatabaseTests.cs
@@ -1,0 +1,64 @@
+using System;
+using FluentAssertions;
+using SkyEditor.RomEditor.Domain.Rtdx.Structures;
+using Xunit;
+
+namespace SkyEditor.RomEditor.Tests.Domain.Structures
+{
+    public class PokemonFormDatabaseTests
+    {
+        [Fact]
+        public void CanBuildPokemonFormDatabaseTests()
+        {
+            // Arrange
+            var entryIds1 = new short[] {10, 11, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            var entryIds2 = new short[] {0, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            
+            var db = new PokemonFormDatabase();
+            db.Entries.Add(new PokemonFormDatabase.PokemonFormDatabaseEntry
+            {
+                PokemonGraphicsDatabaseEntryIds = entryIds1
+            });
+            db.Entries.Add(new PokemonFormDatabase.PokemonFormDatabaseEntry
+            {
+                PokemonGraphicsDatabaseEntryIds = entryIds2
+            });
+
+            // Act
+            var data = db.ToByteArray();
+
+            // Assert
+            var rebuiltDb = new PokemonFormDatabase(data);
+            rebuiltDb.Entries[0].PokemonGraphicsDatabaseEntryIds.Should().Equal(entryIds1);
+            rebuiltDb.Entries[1].PokemonGraphicsDatabaseEntryIds.Should().Equal(entryIds2);
+        }
+        
+        public class PokemonFormDatabaseEntryTests
+        {
+            [Fact]
+            public void ThrowsExceptionWithWrongArraySize()
+            {
+                Action act = () => new PokemonFormDatabase.PokemonFormDatabaseEntry
+                {
+                    PokemonGraphicsDatabaseEntryIds = new short[] { 10, 11, 12 }
+                };
+                
+                // Assert
+                act.Should().Throw<Exception>();
+            }
+            
+            [Fact]
+            public void AcceptsRightArraySize()
+            {
+                // Act
+                Action act = () => new PokemonFormDatabase.PokemonFormDatabaseEntry
+                {
+                    PokemonGraphicsDatabaseEntryIds = new short[PokemonFormDatabase.PokemonFormDatabaseEntry.ExpectedIdCount]
+                };
+                
+                // Assert
+                act.Should().NotThrow<Exception>();
+            }
+        }
+    }
+}

--- a/SkyEditor.RomEditor.Rtdx.Tests/Domain/Structures/Sir0StringListTests.cs
+++ b/SkyEditor.RomEditor.Rtdx.Tests/Domain/Structures/Sir0StringListTests.cs
@@ -1,0 +1,29 @@
+using System.Text;
+using FluentAssertions;
+using SkyEditor.RomEditor.Domain.Rtdx.Structures;
+using Xunit;
+
+namespace SkyEditor.RomEditor.Tests.Domain.Structures
+{
+    public class Sir0StringListTests
+    {
+        [Fact]
+        public void CanBuildStringLists()
+        {
+            // Arrange
+            var db = new Sir0StringList(Encoding.Unicode);
+            db.Entries.Add("Red");
+            db.Entries.Add("Blue");
+            db.Entries.Add("Time");
+            db.Entries.Add("Darkness");
+            db.Entries.Add("Sky");
+
+            // Act
+            var data = db.ToByteArray();
+
+            // Assert
+            var rebuiltDb = new Sir0StringList(data);
+            rebuiltDb.Entries.Should().Equal("Red", "Blue", "Time", "Darkness", "Sky");
+        }
+    }
+}

--- a/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/MessageBinEntry.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/MessageBinEntry.cs
@@ -24,8 +24,11 @@ namespace SkyEditor.RomEditor.Domain.Rtdx.Structures
                 var stringOffset = sir0.Data.ReadInt64(entryOffset);
                 var hash = sir0.Data.ReadInt32(entryOffset + 8);
                 var unknown = sir0.Data.ReadInt32(entryOffset + 0xC);
-                strings.Add(hash, sir0.Data.ReadNullTerminatedUnicodeString(stringOffset));
-                hashes.Add(stringOffset, hash);
+                if (!strings.ContainsKey(hash)) // script.bin contains duplicate hashes
+                {
+                    strings.Add(hash, sir0.Data.ReadNullTerminatedUnicodeString(stringOffset));
+                    hashes.Add(stringOffset, hash);
+                }
             }
             Strings = strings;
             OrderedHashes = hashes.OrderBy(h => h.Key).Select(h => h.Value).ToArray();

--- a/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/Sir0StringList.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/Sir0StringList.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.Text;
+using SkyEditor.IO.Binary;
+using SkyEditor.RomEditor.Domain.Common.Structures;
+
+namespace SkyEditor.RomEditor.Domain.Rtdx.Structures
+{
+    public class Sir0StringList
+    {
+        public List<string> Entries { get; } = new List<string>();
+
+        private Encoding encoding;
+
+        public Sir0StringList(Encoding encoding)
+        {
+            this.encoding = encoding;
+        }
+
+        public Sir0StringList(byte[] data) : this(data, Encoding.Unicode)
+        {
+        }
+        
+        public Sir0StringList(byte[] data, Encoding encoding)
+        {
+            this.encoding = encoding;
+            
+            var sir0 = new Sir0(data);
+
+            var entryCount = sir0.SubHeader.ReadInt32(0);
+            for (int i = 0; i < entryCount; i++)
+            {
+                long stringOffset = sir0.SubHeader.ReadInt32(8 + i * sizeof(long));
+                string value = sir0.Data.ReadNullTerminatedUnicodeString(stringOffset);
+                Entries.Add(value);
+            }
+        }
+        
+        public Sir0 ToSir0()
+        {
+            var sir0 = new Sir0Builder(8);
+            
+            void align(int length)
+            {
+                var paddingLength = length - (sir0.Length % length);
+                if (paddingLength != length)
+                {
+                    sir0.WritePadding(sir0.Length, paddingLength);
+                }
+            }
+            
+            var pointers = new List<int>();
+            
+            var entriesSectionStart = sir0.Length;
+
+            // Write the strings
+            foreach (var entry in Entries)
+            {
+                pointers.Add(sir0.Length);
+                sir0.WriteNullTerminatedString(sir0.Length, encoding, entry);
+            }
+
+            // Write the pointers
+            align(8);
+            sir0.SubHeaderOffset = sir0.Length;
+            sir0.WriteInt64(sir0.Length, Entries.Count);
+            foreach (int pointer in pointers)
+            {
+                sir0.WritePointer(sir0.Length, pointer);
+            }
+            return sir0.Build();
+        }
+        
+        public byte[] ToByteArray() => ToSir0().Data.ReadArray();
+    }
+}


### PR DESCRIPTION
Adds editing support for pokemon_form_database.bin and allows reading and writing dungeon_map_symbol.bin and dungeon_bgm_symbol.bin. The latter two are currently not very useful since we don't know where they are referenced yet