### PR TITLE
Read and write experience.bin/ent

### DIFF
--- a/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Queries/Rtdx/ListPokemonDataInfo.csx
+++ b/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Queries/Rtdx/ListPokemonDataInfo.csx
@@ -3,6 +3,7 @@
 using System;
 
 var pokemonInfo = Rom.GetPokemonDataInfo();
+var experience = Rom.GetExperience();
 var strings = Rom.GetCommonStrings();
 foreach (var pokemon in pokemonInfo.Entries)
 {
@@ -21,6 +22,24 @@ foreach (var pokemon in pokemonInfo.Entries)
     Console.WriteLine($"SPD: {pokemon.BaseSpecialDefense}");
     Console.WriteLine($"SPE: {pokemon.BaseSpeed}");
     Console.WriteLine($"Experience Table ID: {pokemon.ExperienceEntry}");
+    var expTable = experience.Entries[pokemon.ExperienceEntry];
+    var currHP = pokemon.BaseHitPoints;
+    var currAtk = pokemon.BaseAttack;
+    var currDef = pokemon.BaseDefense;
+    var currSpA = pokemon.BaseSpecialAttack;
+    var currSpD = pokemon.BaseSpecialDefense;
+    var currSpe = pokemon.BaseSpeed;
+    for (int i = 1; i < 100; i++)
+    {
+        var level = expTable.Levels[i];
+        currHP += level.HitPointsGained;
+        currAtk += level.AttackGained;
+        currDef += level.DefenseGained;
+        currSpA += level.SpecialAttackGained;
+        currSpD += level.SpecialDefenseGained;
+        currSpe += level.SpeedGained;
+        Console.WriteLine($" - to {i + 1,3}:  XP: {level.MinimumExperience,7}   +{level.HitPointsGained} HP  +{level.AttackGained} Atk  +{level.DefenseGained} Def  +{level.SpecialAttackGained} SpA  +{level.SpecialDefenseGained} SpD  +{level.SpeedGained} Spe  =>  {currHP,3} HP  {currAtk,3} Atk  {currDef,3} Def  {currSpA,3} SpA  {currSpD,3} SpD  {currSpe,3} Spe");
+    }
     if (!string.IsNullOrWhiteSpace(pokemon.RecruitPrereq))
     {
         Console.WriteLine($"Recruitment Prereq: {pokemon.RecruitPrereq}");

--- a/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/RtdxRom.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/RtdxRom.cs
@@ -47,6 +47,8 @@ namespace SkyEditor.RomEditor.Domain.Rtdx
 
         #region StreamingAssets/native_data/pokemon
         PokemonDataInfo GetPokemonDataInfo();
+
+        IExperience GetExperience();
         #endregion
 
         #region StreamingAssets/native_data/dungeon
@@ -186,6 +188,17 @@ namespace SkyEditor.RomEditor.Domain.Rtdx
         }
         private PokemonDataInfo? pokemonDataInfo;
         protected static string GetPokemonDataInfoPath(string directory) => Path.Combine(directory, "romfs/Data/StreamingAssets/native_data/pokemon/pokemon_data_info.bin");
+
+        public IExperience GetExperience()
+        {
+            if (experience == null)
+            {
+                experience = new Experience(new BinaryFile(GetExperiencePath(this.RomDirectory) + ".bin"), new BinaryFile(GetExperiencePath(this.RomDirectory) + ".ent"));
+            }
+            return experience;
+        }
+        private IExperience? experience;
+        protected static string GetExperiencePath(string directory) => Path.Combine(directory, "romfs/Data/StreamingAssets/native_data/pokemon/experience");
 
         #endregion
 

--- a/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/RtdxRom.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/RtdxRom.cs
@@ -434,6 +434,14 @@ namespace SkyEditor.RomEditor.Domain.Rtdx
                 EnsureDirectoryExists(path);
                 fileSystem.WriteAllBytes(path, pokemonDataInfo.ToByteArray());
             }
+            if (experience != null)
+            {
+                var path = GetExperiencePath(directory);
+                EnsureDirectoryExists(path);
+                var (binData, entData) = experience.Build();
+                fileSystem.WriteAllBytes(path + ".bin", binData);
+                fileSystem.WriteAllBytes(path + ".ent", entData);
+            }
 
             // To-do: save commonStrings when implemented
             

--- a/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/Experience.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/Experience.cs
@@ -1,0 +1,68 @@
+﻿using SkyEditor.IO.Binary;
+using System.Collections.Generic;
+
+namespace SkyEditor.RomEditor.Domain.Rtdx.Structures
+{
+    public interface IExperience
+    {
+        IReadOnlyList<Experience.ExperienceEntry> Entries { get; }
+    }
+
+    public class Experience : IExperience
+    {
+        public IReadOnlyList<ExperienceEntry> Entries { get; }
+
+        public Experience(IReadOnlyBinaryDataAccessor data, IReadOnlyBinaryDataAccessor entryList)
+        {
+            var entryCount = checked((int)entryList.Length / sizeof(int));
+            var entries = new List<ExperienceEntry>(entryCount);
+            for (int i = 0; i < entryCount - 1; i++)
+            {
+                var entryOffset = entryList.ReadInt32(i * sizeof(int));
+                var entryEnd = entryList.ReadInt32((i + 1) * sizeof(int));
+                entries.Add(new ExperienceEntry(data.Slice(entryOffset, entryEnd - entryOffset)));
+            }
+            this.Entries = entries;
+        }
+
+        public class ExperienceEntry
+        {
+            private const int EntrySize = 0x0C;
+
+            public IReadOnlyList<Level> Levels { get; }
+
+            public ExperienceEntry(IReadOnlyBinaryDataAccessor data)
+            {
+                var levelCount = checked((int)data.Length / EntrySize);
+                var levels = new List<Level>(levelCount);
+                for (int i = 0; i < levelCount; i++)
+                    levels.Add(new Level(data.Slice(i * EntrySize, EntrySize)));
+                this.Levels = levels;
+            }
+
+            public class Level
+            {
+                public int MinimumExperience { get; }
+                public byte HitPointsGained { get; }
+                public byte AttackGained { get; }
+                public byte SpecialAttackGained { get; }
+                public byte DefenseGained { get; }
+                public byte SpecialDefenseGained { get; }
+                public byte SpeedGained { get; }
+                public byte LevelsGained { get; }
+
+                public Level(IReadOnlyBinaryDataAccessor data)
+                {
+                    MinimumExperience = data.ReadInt32(0);
+                    HitPointsGained = data.ReadByte(0x4);
+                    AttackGained = data.ReadByte(0x5);
+                    SpecialAttackGained = data.ReadByte(0x6);
+                    DefenseGained = data.ReadByte(0x7);
+                    SpecialDefenseGained = data.ReadByte(0x8);
+                    SpeedGained = data.ReadByte(0x9);
+                    LevelsGained = data.ReadByte(0xA);
+                }
+            }
+        }
+    }
+}

--- a/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/Experience.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/Experience.cs
@@ -1,11 +1,16 @@
-﻿using SkyEditor.IO.Binary;
+﻿using AssetStudio;
+using SkyEditor.IO.Binary;
+using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.IO;
 
 namespace SkyEditor.RomEditor.Domain.Rtdx.Structures
 {
     public interface IExperience
     {
         IReadOnlyList<Experience.ExperienceEntry> Entries { get; }
+        (byte[] bin, byte[] ent) Build();
     }
 
     public class Experience : IExperience
@@ -23,6 +28,38 @@ namespace SkyEditor.RomEditor.Domain.Rtdx.Structures
                 entries.Add(new ExperienceEntry(data.Slice(entryOffset, entryEnd - entryOffset)));
             }
             this.Entries = entries;
+        }
+
+        public (byte[] bin, byte[] ent) Build()
+        {
+            MemoryStream bin = new MemoryStream();
+            var entryPointers = new List<int>();
+
+            // Build the .bin file data
+            entryPointers.Add(0);
+            foreach (var entry in Entries)
+            {
+                // Write data to .bin and the pointer to .ent
+                // Align data to 16 bytes
+                var binData = entry.ToByteArray();
+                bin.Write(binData, 0, binData.Length);
+                var paddingLength = 16 - (bin.Length % 16);
+                if (paddingLength != 16)
+                {
+                    bin.SetLength(bin.Length + paddingLength);
+                    bin.Position = bin.Length;
+                }
+                entryPointers.Add((int)bin.Position);
+            }
+
+            // Build the .ent file data
+            var ent = new byte[entryPointers.Count * sizeof(int)];
+            for (int i = 0; i < entryPointers.Count; i++)
+            {
+                BinaryPrimitives.WriteInt32LittleEndian(ent.AsSpan().Slice(i * sizeof(int)), entryPointers[i]);
+            }
+
+            return (bin.ToArray(), ent);
         }
 
         public class ExperienceEntry
@@ -53,7 +90,7 @@ namespace SkyEditor.RomEditor.Domain.Rtdx.Structures
 
                 public Level(IReadOnlyBinaryDataAccessor data)
                 {
-                    MinimumExperience = data.ReadInt32(0);
+                    MinimumExperience = data.ReadInt32(0x0);
                     HitPointsGained = data.ReadByte(0x4);
                     AttackGained = data.ReadByte(0x5);
                     SpecialAttackGained = data.ReadByte(0x6);
@@ -62,6 +99,25 @@ namespace SkyEditor.RomEditor.Domain.Rtdx.Structures
                     SpeedGained = data.ReadByte(0x9);
                     LevelsGained = data.ReadByte(0xA);
                 }
+            }
+
+            public byte[] ToByteArray()
+            {
+                var data = new byte[EntrySize * Levels.Count];
+                for (var i = 0; i < Levels.Count; i++)
+                {
+                    var level = Levels[i];
+                    var slice = data.AsSpan().Slice(i * EntrySize);
+                    BinaryPrimitives.WriteInt32LittleEndian(slice.Slice(0x0), level.MinimumExperience);
+                    slice[0x4] = level.HitPointsGained;
+                    slice[0x5] = level.AttackGained;
+                    slice[0x6] = level.SpecialAttackGained;
+                    slice[0x7] = level.DefenseGained;
+                    slice[0x8] = level.SpecialDefenseGained;
+                    slice[0x9] = level.SpeedGained;
+                    slice[0xA] = level.LevelsGained;
+                }
+                return data;
             }
         }
     }

--- a/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/MessageBinEntry.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/MessageBinEntry.cs
@@ -57,7 +57,7 @@ namespace SkyEditor.RomEditor.Domain.Rtdx.Structures
         public Dictionary<long, List<MessageBinString>> Strings { get; }
         public IReadOnlyList<int> OrderedHashes { get; }
 
-        public string GetStringByHash(int hash) => Strings[hash].FirstOrDefault().Value;
+        public string GetStringByHash(int hash) => Strings.ContainsKey(hash) ? Strings[hash].FirstOrDefault().Value : "";
 
         public void AddString(string key, string value)
         {

--- a/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/PokemonDataInfo.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/PokemonDataInfo.cs
@@ -66,8 +66,8 @@ namespace SkyEditor.RomEditor.Domain.Rtdx.Structures
 
             public short BaseHitPoints { get; set; }
             public short BaseAttack { get; set; }
-            public short BaseDefense { get; set; }
             public short BaseSpecialAttack { get; set; }
+            public short BaseDefense { get; set; }
             public short BaseSpecialDefense { get; set; }
             public short BaseSpeed { get; set; }
 
@@ -121,8 +121,8 @@ namespace SkyEditor.RomEditor.Domain.Rtdx.Structures
 
                 BaseHitPoints = data.ReadInt16(0x74);
                 BaseAttack = data.ReadInt16(0x76);
-                BaseDefense = data.ReadInt16(0x78);
-                BaseSpecialAttack = data.ReadInt16(0x7A);
+                BaseSpecialAttack = data.ReadInt16(0x78);
+                BaseDefense = data.ReadInt16(0x7A);
                 BaseSpecialDefense = data.ReadInt16(0x7C);
                 BaseSpeed = data.ReadInt16(0x7E);
 
@@ -171,8 +171,8 @@ namespace SkyEditor.RomEditor.Domain.Rtdx.Structures
 
                 BinaryPrimitives.WriteInt16LittleEndian(buffer.Slice(0x74), BaseHitPoints);
                 BinaryPrimitives.WriteInt16LittleEndian(buffer.Slice(0x76), BaseAttack);
-                BinaryPrimitives.WriteInt16LittleEndian(buffer.Slice(0x78), BaseDefense);
-                BinaryPrimitives.WriteInt16LittleEndian(buffer.Slice(0x7A), BaseSpecialAttack);
+                BinaryPrimitives.WriteInt16LittleEndian(buffer.Slice(0x78), BaseSpecialAttack);
+                BinaryPrimitives.WriteInt16LittleEndian(buffer.Slice(0x7A), BaseDefense);
                 BinaryPrimitives.WriteInt16LittleEndian(buffer.Slice(0x7C), BaseSpecialDefense);
                 BinaryPrimitives.WriteInt16LittleEndian(buffer.Slice(0x7E), BaseSpeed);
 


### PR DESCRIPTION
Speedrunners were interested in the data contained in these files. Might as well add full editing support for them.

The `Experience` data structure originated from AntyMew's fork. I made a few corrections and added writing support. Assuming the original data files are read from the ROM, calling `Build()` without modifying any entries produces two byte arrays that perfectly match the source `bin/ent` files.