### PR TITLE
Add initial support for encoding and decoding message.bin strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ bld/
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 
+# VS Code directory
+.vscode/
+
 # Rider cache directory
 .idea/
 

--- a/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Queries/Rtdx/ListCodeTable.csx
+++ b/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Queries/Rtdx/ListCodeTable.csx
@@ -3,7 +3,8 @@
 using System;
 
 var table = Rom.GetCodeTable();
-foreach (var entry in table.Entries)
+foreach (var entry in table.EntriesByCodeString.Values)
 {
-    Console.WriteLine($"[{entry.CodeString}] = {entry.UnicodeValue.ToString("X")} (ukn = {entry.Unknown.ToString("X")})");
+    Console.WriteLine($"[{entry.CodeString}] = {entry.UnicodeValue.ToString("X")} (ukn = {entry.Unknown.ToString("X")}, "
+        + $"flags = {entry.Flags.ToString("X")}), replaceByte0 = {entry.DigitFlag}");
 }

--- a/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Queries/Rtdx/MessageBinEncoding.csx
+++ b/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Queries/Rtdx/MessageBinEncoding.csx
@@ -1,0 +1,19 @@
+#load "../../../Stubs/Rtdx.csx"
+
+using System;
+using SkyEditor.RomEditor.Domain.Rtdx.Structures;
+using SkyEditor.RomEditor.Infrastructure;
+
+var codeTable = Rom.GetCodeTable();
+var messageBin = new MessageBinEntry(Rom.GetUSMessageBin().GetFile("script.bin"));
+
+string encodedText = messageBin.GetStringByHash((int) Crc32Hasher.Crc32Hash("SCRIPT__B01P01A_M01E01A_3_02_0360"));
+Console.WriteLine(encodedText);
+
+string decodedText = codeTable.UnicodeDecode(encodedText);
+Console.WriteLine(decodedText);
+Console.WriteLine(codeTable.UnicodeEncode(decodedText));
+
+encodedText = codeTable.UnicodeEncode("Hello [hero] and [partner], press the [M:B03] button to evolve. This should stay intact: [test]");
+Console.WriteLine(encodedText);
+Console.WriteLine(codeTable.UnicodeDecode(encodedText));

--- a/SkyEditor.RomEditor.Rtdx.Tests/Domain/Structures/CodeTableTests.cs
+++ b/SkyEditor.RomEditor.Rtdx.Tests/Domain/Structures/CodeTableTests.cs
@@ -1,0 +1,52 @@
+using System;
+using FluentAssertions;
+using SkyEditor.RomEditor.Domain.Rtdx.Structures;
+using Xunit;
+
+namespace SkyEditor.RomEditor.Tests.Domain.Structures
+{
+    public class CodeTableTests
+    {
+        [Fact]
+        public void CanEncodeAndDecode()
+        {
+            // Arrange
+            var codeTable = new CodeTable();
+            codeTable.AddEntry(new CodeTable.Entry
+            {
+                CodeString = "hero",
+                UnicodeValue = 0xD100,
+            });
+            codeTable.AddEntry(new CodeTable.Entry
+            {
+                CodeString = "partner",
+                UnicodeValue = 0xD200,
+            });
+            codeTable.AddEntry(new CodeTable.Entry
+            {
+                CodeString = "M:B01",
+                UnicodeValue = 0xA08A,
+            });
+            codeTable.AddEntry(new CodeTable.Entry
+            {
+                CodeString = "kind_p:",
+                UnicodeValue = 0xE400,
+                Flags = 1 // Flag bit 0 means that a value can be encoded
+            });
+            string originalString = "Hello [hero] and [partner], press the [M:B01] button to evolve to [kind_p:25] and [kind_p:90]";
+
+            // Act
+            var encodedString = codeTable.UnicodeEncode(originalString);
+            var decodedString = codeTable.UnicodeDecode(encodedString);
+
+            // Assert
+            char unicode(ushort value)
+            {
+                return (char) value;
+            }
+            encodedString.Should().Be($"Hello {unicode(0xD100)} and {unicode(0xD200)}, "
+                + $"press the {unicode(0xA08A)} button to evolve to {unicode(0xE400 + 25)} and {unicode(0xE400 + 90)}");
+            decodedString.Should().Be(originalString);
+        }
+    }
+}

--- a/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/CodeTable.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/CodeTable.cs
@@ -1,13 +1,33 @@
+using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Text.RegularExpressions;
 using SkyEditor.IO.Binary;
 using SkyEditor.RomEditor.Domain.Common.Structures;
 
 namespace SkyEditor.RomEditor.Domain.Rtdx.Structures
 {
+    /// <summary>
+    /// This class allows encoding and decoding strings between human-readable text directives like [hero]
+    /// and an internal representation with special Unicode characters.
+    /// </summary>
+    /// <remarks>
+    /// Note that the code_table.bin file is used, which doesn't always match the directives that are used
+    /// in the Japanese text inside the .lua files. It seems like the game uses either a combination of hard-coded
+    /// regular expressions and code_table.bin to parse these or even hardcodes everything and ignores code_table.bin
+    /// completely. However, this should work for assembling custom text with the most common directives
+    /// like [hero], [partner] etc.
+    /// </remarks>
     public class CodeTable
     {
-        public List<Entry> Entries { get; } = new List<Entry>();
+        public Dictionary<ushort, Entry> EntriesByUnicode { get; } = new Dictionary<ushort, Entry>();
+        public Dictionary<string, Entry> EntriesByCodeString { get; } = new Dictionary<string, Entry>();
+
+        private static readonly Regex StringTokenRegex = new Regex("\\[(.+?:?)(\\d+)*\\]", RegexOptions.Compiled);
+
+        public CodeTable()
+        {
+        }
         
         public CodeTable(byte[] data)
         {            
@@ -18,23 +38,108 @@ namespace SkyEditor.RomEditor.Domain.Rtdx.Structures
                 long pointerOffset = sir0.PointerOffsets[i];
                 long stringOffset = sir0.Data.ReadInt64(pointerOffset);
                 string codeString = sir0.Data.ReadNullTerminatedUnicodeString(stringOffset);
-                int unicodeValue = sir0.Data.ReadInt32(pointerOffset + 8);
+                ushort unicodeValue = sir0.Data.ReadUInt16(pointerOffset + 8);
+                ushort flags = sir0.Data.ReadUInt16(pointerOffset + 10);
                 int unknown = sir0.Data.ReadInt32(pointerOffset + 12);
-
-                Entries.Add(new Entry
+                
+                AddEntry(new Entry
                 {
                     CodeString = codeString,
                     UnicodeValue = unicodeValue,
+                    Flags = flags,
                     Unknown = unknown,
                 });
             }
         }
 
+        public void AddEntry(Entry entry)
+        {
+            if (!EntriesByUnicode.ContainsKey(entry.UnicodeValue))
+            {
+                // There are duplicate unicode values in the table
+                // TODO: more robust handling (maybe consider the Unknown as well)
+                EntriesByUnicode.Add(entry.UnicodeValue, entry);
+            }
+            EntriesByCodeString.Add(entry.CodeString, entry);
+        }
+
+        // Replaces special text tokens with Unicode symbols for message.bin
+        public string UnicodeEncode(string text)
+        {
+            var sb = new StringBuilder();
+
+            var match = StringTokenRegex.Match(text);
+            int lastStringPos = 0;
+            while (match.Success)
+            {
+                sb.Append(text.Substring(lastStringPos, match.Index - lastStringPos));
+                string directive = match.Groups[1].Value;
+                string? value = match.Groups.Count > 1 ? match.Groups[2].Value : null;
+
+                if (!string.IsNullOrEmpty(value) && EntriesByCodeString.TryGetValue(directive + value, out var entry))
+                {
+                    // Sometimes the directive and value are both included (e.g. [M:B01])
+                    sb.Append((char) entry.UnicodeValue);
+                }
+                else if (EntriesByCodeString.TryGetValue(directive, out entry)) 
+                {
+                    ushort unicodeValue = entry.UnicodeValue;
+                    if (entry.DigitFlag && value != null)
+                    {
+                        // Encode the value into the two low bytes
+                        // TODO: figure out how the game encodes values that are bigger than bytes (e.g. Pokédex numbers)
+                        unicodeValue = (ushort) ((unicodeValue & 0xFF00) | byte.Parse(value));
+                    }
+                    sb.Append((char) unicodeValue);
+                }
+                else
+                {
+                    sb.Append(match.Value);
+                }
+                lastStringPos = match.Index + match.Length;
+                match = match.NextMatch();
+            }
+
+            sb.Append(text.Substring(lastStringPos, text.Length - lastStringPos));
+            return sb.ToString();
+        }
+
+        // Replaces Unicode symbols from message.bin with human readable text tokens
+        public string UnicodeDecode(string text)
+        {
+            var sb = new StringBuilder();
+            foreach (var character in text)
+            {
+                var bytes = Encoding.Unicode.GetBytes(new char[] { character });
+                ushort shortCharacter = BitConverter.ToUInt16(bytes, 0);
+                if (EntriesByUnicode.TryGetValue(shortCharacter, out var entry))
+                {
+                    // A direct match for the character was found
+                    sb.Append($"[{entry.CodeString}]");
+                }
+                else if (EntriesByUnicode.TryGetValue((ushort) (shortCharacter & 0xFF00), out entry))
+                {
+                    // A match for the low bytes was found, which means that it encodes some other value
+                    sb.Append($"[{entry.CodeString}{shortCharacter & 0x00FF}]");
+                }
+                else
+                {
+                    sb.Append(character);
+                }
+            }
+            return sb.ToString();
+        }
+
         public class Entry
         {
             public string CodeString { get; set; } = "";
-            public int UnicodeValue { get; set; }
+            public ushort UnicodeValue { get; set; }
+            public ushort Flags { get; set; }
             public int Unknown { get; set; }
+
+            // If the flag bit 0 is set, byte 0 of the unicode character
+            // will be replaced with the number after ":" in the string
+            public bool DigitFlag => (Flags & 1) != 0;
         }
     }
 }


### PR DESCRIPTION
Adds support for encoding and decoding between human-readable text directives like and the internal representation with special Unicode characters. The output currently differs from the directives in the Japanese text in Lua files and some cases aren't handled correctly, but this should be good enough to toy around with custom dialogue.