### PR TITLE
Fix message encoding with encoded values

### DIFF
--- a/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Queries/Rtdx/ListCodeTable.csx
+++ b/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Queries/Rtdx/ListCodeTable.csx
@@ -1,10 +1,11 @@
 #load "../../../Stubs/Rtdx.csx"
 
 using System;
+using SkyEditor.RomEditor.Domain.Rtdx.Structures;
 
-var table = Rom.GetCodeTable();
+var table = (RtdxCodeTable) Rom.GetCodeTable();
 foreach (var entry in table.EntriesByCodeString.Values)
 {
-    Console.WriteLine($"[{entry.CodeString}] = {entry.UnicodeValue.ToString("X")} (ukn = {entry.Unknown.ToString("X")}, "
-        + $"flags = {entry.Flags.ToString("X")}), replaceByte0 = {entry.DigitFlag}");
+    Console.WriteLine($"[{entry.CodeString}] = {entry.UnicodeValue.ToString("X")} (ukn = {entry.Unknown.ToString("X")}, length = {entry.Length}, "
+        + $"flags = {entry.Flags.ToString("X")}), digitFlag = {entry.DigitFlag}");
 }

--- a/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Queries/Rtdx/MessageBinEncoding.csx
+++ b/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Queries/Rtdx/MessageBinEncoding.csx
@@ -7,13 +7,13 @@ using SkyEditor.RomEditor.Infrastructure;
 var codeTable = Rom.GetCodeTable();
 var messageBin = new MessageBinEntry(Rom.GetUSMessageBin().GetFile("script.bin"));
 
-string encodedText = messageBin.GetStringByHash((int) Crc32Hasher.Crc32Hash("SCRIPT__B01P01A_M01E01A_3_02_0360"));
+string encodedText = messageBin.GetStringByHash((int) Crc32Hasher.Crc32Hash("SCRIPT__PEGID_HANYOU_OHAYOUKURINOMI__8384"));
 Console.WriteLine(encodedText);
 
 string decodedText = codeTable.UnicodeDecode(encodedText);
 Console.WriteLine(decodedText);
 Console.WriteLine(codeTable.UnicodeEncode(decodedText));
 
-encodedText = codeTable.UnicodeEncode("Hello [hero] and [partner], press the [M:B03] button to evolve. This should stay intact: [test]");
+encodedText = codeTable.UnicodeEncode("Hello [hero] and [partner], press the [M:B03] button to evolve with a [item:226]. This should stay intact: [test]");
 Console.WriteLine(encodedText);
 Console.WriteLine(codeTable.UnicodeDecode(encodedText));

--- a/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Utilities/Rtdx/AddDialogueComments.csx
+++ b/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Utilities/Rtdx/AddDialogueComments.csx
@@ -7,10 +7,11 @@ using System.IO;
 using SkyEditor.RomEditor.Domain.Rtdx.Constants;
 using SkyEditor.RomEditor.Domain.Rtdx;
 using SkyEditor.RomEditor.Domain.Rtdx.Structures;
+using SkyEditor.RomEditor.Infrastructure;
 using System.Text.RegularExpressions;
 
 var usMessageBin = Rom.GetUSMessageBin();
-var scriptStrings = new MessageBinEntry(Rom.GetUSMessageBin().GetFile("script.bin"));
+var scriptStrings = new MessageBinEntry(Rom.GetUSMessageBin().GetFile("script.bin"), Rom.GetCodeTable());
 
 string LuaScriptsPath = Path.Combine(Rom.RomDirectory, "romfs", "Data", "StreamingAssets", "native_data", "script", "event");
 
@@ -29,14 +30,14 @@ foreach (var luaFile in new DirectoryInfo(LuaScriptsPath).GetFiles("*.lua", Sear
     string textId = match.Groups["textIdValue"].Value;
 
     // Story script strings are prefixed with "SCRIPT__"
-    int textIdHash = (int) Farc.PmdHashing.Crc32Hash("SCRIPT__" + textId);
+    int textIdHash = (int)Crc32Hasher.Crc32Hash("SCRIPT__" + textId);
 
     if (!scriptStrings.Strings.ContainsKey(textIdHash))
     {
       continue;
     }
 
-    string dialogueLine = scriptStrings.Strings[textIdHash].Replace("\n", "\\n");
+    string dialogueLine = scriptStrings.Strings[textIdHash].First().Value.Replace("\n", "\\n");
     lines[i] = $"{line} -- {dialogueLine}";
   }
 

--- a/SkyEditor.RomEditor.Rtdx.Tests/Domain/Structures/CodeTableTests.cs
+++ b/SkyEditor.RomEditor.Rtdx.Tests/Domain/Structures/CodeTableTests.cs
@@ -1,6 +1,5 @@
-using System;
 using FluentAssertions;
-using SkyEditor.RomEditor.Domain.Rtdx.Structures;
+using SkyEditor.RomEditor.Domain.Common.Structures;
 using Xunit;
 
 namespace SkyEditor.RomEditor.Tests.Domain.Structures

--- a/SkyEditor.RomEditor.Rtdx/Domain/Common/Structures/CodeTable.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Common/Structures/CodeTable.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using SkyEditor.IO.Binary;
+
+namespace SkyEditor.RomEditor.Domain.Common.Structures
+{
+    public interface ICodeTable
+    {
+        void AddEntry(CodeTable.Entry entry);
+
+        /// <summary>
+        /// Replaces special text tokens with Unicode symbols for message.bin
+        /// </summary>
+        /// <param name="text">User-friendly text</param>
+        string UnicodeEncode(string text);
+
+        /// <summary>
+        /// Replaces Unicode symbols from message.bin with human readable text tokens
+        /// </summary>
+        /// <param name="text">Encoded text</param>
+        string UnicodeDecode(string text);
+    }
+
+    /// <summary>
+    /// This class allows encoding and decoding strings between human-readable text directives like [hero]
+    /// and an internal representation with special Unicode characters.
+    /// </summary>
+    /// <remarks>
+    /// Note that the code_table.bin file is used, which doesn't always match the directives that are used
+    /// in the Japanese text inside the .lua files. It seems like the game uses either a combination of hard-coded
+    /// regular expressions and code_table.bin to parse these or even hardcodes everything and ignores code_table.bin
+    /// completely. However, this should work for assembling custom text with the most common directives
+    /// like [hero], [partner] etc.
+    /// </remarks>
+    // Thanks to Blue and EddyK for figuring out the encoding details.
+    public class CodeTable : ICodeTable
+    {
+        private static readonly Regex StringTokenRegex = new Regex("\\[(.+?:?)(\\w+)*\\]", RegexOptions.Compiled);
+
+        public CodeTable()
+        {
+        }
+
+        public CodeTable(byte[] data)
+        {
+            var sir0 = new Sir0(data);
+
+            for (int i = 3; i < sir0.PointerOffsets.Count - 2; i++)
+            {
+                long pointerOffset = sir0.PointerOffsets[i];
+                long stringOffset = sir0.Data.ReadInt64(pointerOffset);
+                string codeString = sir0.Data.ReadNullTerminatedUnicodeString(stringOffset);
+                ushort unicodeValue = sir0.Data.ReadUInt16(pointerOffset + 8);
+                ushort flags = sir0.Data.ReadUInt16(pointerOffset + 10);
+                short length = sir0.Data.ReadInt16(pointerOffset + 12);
+                short unknown = sir0.Data.ReadInt16(pointerOffset + 14);
+
+                AddEntry(new Entry
+                {
+                    CodeString = codeString,
+                    UnicodeValue = unicodeValue,
+                    Flags = flags,
+                    Length = length,
+                    Unknown = unknown,
+                });
+            }
+        }
+
+        public Dictionary<ushort, Entry> EntriesByUnicode { get; } = new Dictionary<ushort, Entry>();
+        public Dictionary<string, Entry> EntriesByCodeString { get; } = new Dictionary<string, Entry>();
+
+        public void AddEntry(Entry entry)
+        {
+            if (!EntriesByUnicode.ContainsKey(entry.UnicodeValue))
+            {
+                // There are duplicate unicode values in the table
+                // TODO: more robust handling (maybe consider the Unknown as well)
+                EntriesByUnicode.Add(entry.UnicodeValue, entry);
+            }
+            EntriesByCodeString.Add(entry.CodeString, entry);
+        }
+
+        /// <summary>
+        /// Replaces special text tokens with Unicode symbols for message.bin
+        /// </summary>
+        /// <param name="text">User-friendly text</param>
+        public string UnicodeEncode(string text)
+        {
+            var sb = new StringBuilder();
+
+            var match = StringTokenRegex.Match(text);
+            int lastStringPos = 0;
+
+            while (match.Success)
+            {
+                sb.Append(text.Substring(lastStringPos, match.Index - lastStringPos));
+                string directive = match.Groups[1].Value;
+                string? valueString = match.Groups.Count > 1 ? match.Groups[2].Value : null;
+
+                if (!string.IsNullOrEmpty(valueString) && EntriesByCodeString.TryGetValue(directive + valueString, out var entry))
+                {
+                    // Sometimes the directive and value are both included (e.g. [M:B01])
+                    sb.Append((char)entry.UnicodeValue);
+                }
+                else if (EntriesByCodeString.TryGetValue(directive, out entry))
+                {
+                    ushort unicodeValue = entry.UnicodeValue;
+                    if (entry.DigitFlag && valueString != null)
+                    {
+                        uint value;
+                        if (ConstantReplacementTable.TryGetValue(entry.CodeString, out var enumType))
+                        {
+                            value = Convert.ToUInt32(Enum.Parse(enumType, valueString));
+                        }
+                        else
+                        {
+                            value = uint.Parse(valueString);
+                        }
+
+                        // Encode the value into the two low bytes.
+                        // It seems like one of the bytes inside the value is encoded redundantly.
+                        unicodeValue = (ushort)((unicodeValue & 0xFF00) | (byte)value);
+                        sb.Append((char)unicodeValue);
+
+                        if (entry.Length > 0)
+                        {
+                            if (entry.Length > 2)
+                            {
+                                throw new Exception("Invalid entry length.");
+                            }
+
+                            byte[] bytes = BitConverter.GetBytes(value + 1);
+                            sb.Append(Encoding.Unicode.GetString(bytes, 0, entry.Length * 2));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append((char)unicodeValue);
+                    }
+                }
+                else
+                {
+                    sb.Append(match.Value);
+                }
+                lastStringPos = match.Index + match.Length;
+                match = match.NextMatch();
+            }
+
+            sb.Append(text.Substring(lastStringPos, text.Length - lastStringPos));
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Replaces Unicode symbols from message.bin with human readable text tokens
+        /// </summary>
+        /// <param name="text">Encoded text</param>
+        public string UnicodeDecode(string text)
+        {
+            var sb = new StringBuilder();
+            var textBytes = Encoding.Unicode.GetBytes(text);
+            for (int i = 0; i < textBytes.Length; i += 2)
+            {
+                ushort shortCharacter = BitConverter.ToUInt16(textBytes, i);
+                if (EntriesByUnicode.TryGetValue(shortCharacter, out var entry))
+                {
+                    // A direct match for the character was found
+                    sb.Append($"[{entry.CodeString}]");
+                }
+                else if (EntriesByUnicode.TryGetValue((ushort)(shortCharacter & 0xFF00), out entry))
+                {
+                    // A match for the low bytes was found, which means that it encodes some other value.
+                    // The amount of words to decode is found in the Length.
+                    uint encodedValue = shortCharacter & 0xFFu;
+                    if (entry.Length > 0)
+                    {
+                        encodedValue = 0;
+                        for (int j = 0; j < entry.Length; j++)
+                        {
+                            i += (j + 1) * 2;
+
+                            uint partialValue = BitConverter.ToUInt16(textBytes, i);
+                            encodedValue |= partialValue << (j * 2);
+                        }
+                        encodedValue--;
+                    }
+
+                    string encodedValueString;
+                    if (ConstantReplacementTable.TryGetValue(entry.CodeString, out var enumType))
+                    {
+                        encodedValueString = Enum.GetName(enumType, encodedValue) ?? encodedValue.ToString();
+                    }
+                    else
+                    {
+                        encodedValueString = encodedValue.ToString();
+                    }
+                    sb.Append($"[{entry.CodeString}{encodedValueString}]");
+                }
+                else
+                {
+                    sb.Append(Encoding.Unicode.GetString(textBytes, i, 2));
+                }
+            }
+            return sb.ToString();
+        }
+        protected virtual Dictionary<string, Type> ConstantReplacementTable { get; } = new Dictionary<string, Type>();
+
+        public class Entry
+        {
+            public string CodeString { get; set; } = "";
+            public ushort UnicodeValue { get; set; }
+            public ushort Flags { get; set; }
+            public short Length { get; set; }
+            public short Unknown { get; set; }
+
+            // If the flag bit 0 is set, the next X words will be replaced with the number
+            // after ":" in the string where X is specified in the "Length" field
+            public bool DigitFlag => (Flags & 1) != 0;
+        }
+    }
+}

--- a/SkyEditor.RomEditor.Rtdx/Domain/Psmd/Structures/CodeTable.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Psmd/Structures/CodeTable.cs
@@ -5,24 +5,22 @@ using SkyEditor.RomEditor.Domain.Rtdx.Constants;
 
 namespace SkyEditor.RomEditor.Domain.Rtdx.Structures
 {
-    public class RtdxCodeTable : CodeTable
+    public class PsmdCodeTable : CodeTable
     {
         private static readonly Dictionary<string, Type> StaticConstantReplacementTable = new Dictionary<string, Type>()
         {
-            { "kind_p:", typeof(CreatureIndex) },
-            { "item:", typeof(ItemIndex) },
-            { "dungeon:", typeof(DungeonIndex) },
+            { "kind:", typeof(CreatureIndex) },
             { "ability:", typeof(AbilityIndex) },
             { "waza:", typeof(WazaIndex) },
         };
 
         protected override Dictionary<string, Type> ConstantReplacementTable => StaticConstantReplacementTable;
 
-        public RtdxCodeTable()
+        public PsmdCodeTable()
         {
         }
 
-        public RtdxCodeTable(byte[] data) : base(data)
+        public PsmdCodeTable(byte[] data) : base(data)
         {
         }
     }

--- a/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/RtdxRom.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/RtdxRom.cs
@@ -6,6 +6,7 @@ using SkyEditor.IO.FileSystem;
 using SkyEditor.RomEditor.Infrastructure.Automation.CSharp;
 using SkyEditor.RomEditor.Infrastructure.Automation.Lua;
 using SkyEditor.RomEditor.Infrastructure.Automation.Modpacks;
+using SkyEditor.RomEditor.Domain.Common.Structures;
 using SkyEditor.RomEditor.Domain.Rtdx.Constants;
 using SkyEditor.RomEditor.Domain.Rtdx.Models;
 using SkyEditor.RomEditor.Domain.Rtdx.Structures;
@@ -71,7 +72,7 @@ namespace SkyEditor.RomEditor.Domain.Rtdx
         PokemonFormDatabase GetPokemonFormDatabase();
         Sir0StringList GetDungeonMapSymbol();
         Sir0StringList GetDungeonBgmSymbol();
-        CodeTable GetCodeTable();
+        ICodeTable GetCodeTable();
         #endregion
 
         #region Models
@@ -326,15 +327,15 @@ namespace SkyEditor.RomEditor.Domain.Rtdx
         private Sir0StringList? dungeonBgmSymbol;
         protected static string GetDungeonBgmSymbolPath(string directory) => Path.Combine(directory, "romfs/Data/StreamingAssets/native_data/dungeon_bgm_symbol.bin");
 
-        public CodeTable GetCodeTable()
+        public ICodeTable GetCodeTable()
         {
             if (codeTable == null)
             {
-                codeTable = new CodeTable(FileSystem.ReadAllBytes(GetCodeTablePath(this.RomDirectory)));
+                codeTable = new RtdxCodeTable(FileSystem.ReadAllBytes(GetCodeTablePath(this.RomDirectory)));
             }
             return codeTable;
         }
-        private CodeTable? codeTable;
+        private ICodeTable? codeTable;
         protected static string GetCodeTablePath(string directory) => Path.Combine(directory, "romfs/Data/StreamingAssets/native_data/code_table.bin");
         #endregion
 


### PR DESCRIPTION
Note that still only one value is supported so e.g. `[LINE:value1:value2]` won't work yet (though these are rarely used anyway).