### PR TITLE
Integrate Il2CppInspector for code editing

### DIFF
--- a/SkyEditor.RomEditor.Rtdx.ConsoleApp/Program.cs
+++ b/SkyEditor.RomEditor.Rtdx.ConsoleApp/Program.cs
@@ -59,7 +59,8 @@ namespace SkyEditor.RomEditor.ConsoleApp
             var context = new ConsoleContext
             {
                 FileSystem = fileSystem,
-                RomLibrary = new Library("Library", fileSystem)
+                RomLibrary = new Library("Library", fileSystem),
+                VerboseLogging = args.Any(arg => arg == "--verbose")
             };
 
             while (arguments.TryDequeue(out var arg))
@@ -146,6 +147,10 @@ namespace SkyEditor.RomEditor.ConsoleApp
                 else if (Commands.TryGetValue(arg, out var command))
                 {
                     await command(arguments, context);
+                }
+                else if (arg == "--verbose")
+                {
+                    // Do nothing, verbose logging has already been enabled
                 }
                 else
                 {

--- a/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Samples/Il2CppMetadataExample.csx
+++ b/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Samples/Il2CppMetadataExample.csx
@@ -1,0 +1,15 @@
+﻿#load "../../Stubs/Rtdx.csx"
+
+using System;
+using SkyEditor.RomEditor.Domain.Rtdx.Structures;
+
+ulong offset = Rom.GetMainExecutable().GetIlConstructorOffset("PegasusActDatabase", new string[]{});
+Console.WriteLine($"PegasusActDatabase.ctor() at offset {offset}");
+
+offset = Rom.GetMainExecutable().GetIlMethodOffset("CharacterModel", "SetScarfVisible",
+  new string[]{ typeof(bool).FullName });
+Console.WriteLine($"CharacterModel.SetScarfVisible(System.Boolean) at offset {offset}");
+
+offset = Rom.GetMainExecutable().GetIlMethodOffset("UIWorldMapSet", "OpenDungeonName",
+  new string[]{ "Const.dungeon.Index" });
+Console.WriteLine($"UIWorldMapSet.OpenDungeonName(Const.dungeon.index) at offset {offset}");

--- a/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Utilities/Rtdx/CreateMethodRelativeOffsetCode.csx
+++ b/SkyEditor.RomEditor.Rtdx.ConsoleApp/Scripts/Utilities/Rtdx/CreateMethodRelativeOffsetCode.csx
@@ -1,0 +1,90 @@
+#load "../../Stubs/Rtdx.csx"
+
+// This script helps create binary patches that are resilient against changes between versions by
+// generating code that uses offsets relative to the start of the current function. Call it with
+// [SkyEditor Deluxe console app path] [path to ROM] Scripts/Utilities/Rtdx/CreateMethodRelativeOffsetCode.csx [offset]
+// where the offset is the one displayed in the reverse engineering tool (relative to .text).
+// You can copy the output to your own script to write to the correct offset.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using SkyEditor.RomEditor.Domain.Rtdx.Structures;
+using SkyEditor.RomEditor.Domain.Rtdx.Structures.Executable;
+using SkyEditor.RomEditor.Infrastructure;
+using Newtonsoft.Json;
+using Il2CppInspector.Reflection;
+
+var args = Environment.GetCommandLineArgs();
+if (Convert.ToInt64(args.Last(), 16) < 0)
+{
+  throw new ArgumentException("Call this script with the offset in .text as the last argument.");
+}
+ulong offset = Convert.ToUInt64(args.Last(), 16);
+
+public struct MethodData
+{
+  public string TypeName;
+  public string MethodName;
+  public ulong Offset;
+  public string[] ParameterTypes;
+  public bool IsConstructor;
+}
+
+string homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+string cacheDir = $"{homeDir}/.skyeditor";
+string cacheFile = $"{cacheDir}/ilMethodData.json";
+if (!Directory.Exists(cacheDir))
+{
+  Directory.CreateDirectory(cacheDir);
+}
+
+MethodData[] transformedMethodData;
+if (!File.Exists(cacheFile))
+{
+  // Write to a cache since it would be too slow to read this every time 
+  // TODO: this still takes a while, see if we can make it faster
+  var executable = Rom.GetMainExecutable();
+  ulong textOffset = executable.SectionOffsets[".text"];
+
+  var allMethods = executable.IlAppModel.TypeModel.Types.SelectMany(type => 
+    type.GetAllMethods().Cast<MethodBase>().Concat(type.DeclaredConstructors));
+
+  transformedMethodData = allMethods
+    .Where(m => executable.IlAppModel.Methods.ContainsKey(m))
+    .Select(m => new MethodData {
+      TypeName = m.DeclaringType.FullName,
+      MethodName = m.Name,
+      Offset = executable.IlAppModel.Methods[m].MethodCodeAddress,
+      ParameterTypes = m.DeclaredParameters.Select(p => p.ParameterType.FullName).ToArray(),
+      IsConstructor = m is ConstructorInfo,
+    }).ToArray();
+
+  string serializedData = JsonConvert.SerializeObject(transformedMethodData);
+  File.WriteAllText(cacheFile, serializedData);
+}
+else
+{
+  string serializedData = File.ReadAllText(cacheFile);
+  transformedMethodData = JsonConvert.DeserializeObject<MethodData[]>(serializedData);
+}
+
+var closestMethod = transformedMethodData
+  .Where(m => m.Offset < offset)
+  .OrderByDescending(m => m.Offset)
+  .First();
+
+ulong methodRelativeOffset = offset - closestMethod.Offset;
+string joinedParameters = string.Join(", ", closestMethod.ParameterTypes.Select(t => $"\"{t}\""));
+
+if (closestMethod.IsConstructor)
+{
+  Console.WriteLine($"codeHelper.SetOffsetToConstructor(\"{closestMethod.TypeName}\", "
+    + $"new string[] {{{joinedParameters}}});");
+}
+else
+{
+  Console.WriteLine($"codeHelper.SetOffsetToMethod(\"{closestMethod.TypeName}\", \"{closestMethod.MethodName}\", "
+    + $"new string[] {{{joinedParameters}}});");
+}
+Console.WriteLine($"codeHelper.Offset += 0x{methodRelativeOffset.ToString("x")};");

--- a/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/CodeGenerationHelper.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/CodeGenerationHelper.cs
@@ -1,0 +1,76 @@
+#if !NETSTANDARD2_0
+using System;
+using System.Linq;
+using SkyEditor.RomEditor.Domain.Rtdx.Structures.Executable;
+
+namespace SkyEditor.RomEditor.Domain.Rtdx
+{
+  public class CodeGenerationHelper
+  {
+    public IMainExecutable Executable { get; set; }
+    public ulong Offset { get; set; }
+    public byte[] Data { get; }
+    public ulong GlobalOffset => sectionOffset + Offset;
+
+    private ulong sectionOffset = 0;
+
+    public CodeGenerationHelper(IMainExecutable executable, string codeSectionName = ".text")
+    {
+      Executable = executable;
+      sectionOffset = executable.SectionOffsets[codeSectionName];
+      Data = executable.Data;
+    }
+
+    public void WriteCode(string hexString)
+    {
+      WriteCode(HexStringToByteArray(hexString));
+    }
+
+    public void WriteCode(uint data)
+    {
+      WriteCode(BitConverter.GetBytes(data));
+    }
+
+    public void WriteCode(byte[] bytes)
+    {
+      Array.Copy(bytes, 0, Data, (long) GlobalOffset, bytes.LongLength);
+      Offset += (uint) bytes.Length;
+    }
+
+    public void WriteMethodCall(string fullTypeName, string methodName, string[] paramTypeNames)
+    {
+      ulong methodOffset = Executable.GetIlMethodOffset(fullTypeName, methodName, paramTypeNames);
+      WriteRelativeBranchWithLink(methodOffset - Offset);
+    }
+
+    public void WriteRelativeBranchWithLink(ulong relativeOffset)
+    {
+      WriteCode(GenerateRelativeBranchWithLink(relativeOffset));
+    }
+
+    public void SetOffsetToMethod(string fullTypeName, string methodName, string[] paramTypeNames)
+    {
+      Offset = Executable.GetIlMethodOffset(fullTypeName, methodName, paramTypeNames);
+    }
+
+    public void SetOffsetToConstructor(string fullTypeName, string[] paramTypeNames)
+    {
+      Offset = Executable.GetIlConstructorOffset(fullTypeName, paramTypeNames);
+    }
+
+    public static byte[] HexStringToByteArray(string hexString)
+    {
+      return Enumerable.Range(0, hexString.Length / 2) 
+        .Select(x => Convert.ToByte(hexString.Substring(x * 2, 2), 16))
+        .ToArray();
+    }
+
+    public static uint GenerateRelativeBranchWithLink(ulong relativeOffset)
+    {
+      // http://shell-storm.org/armv8-a/ISA_v85A_A64_xml_00bet8_OPT/xhtml/bl.html
+      uint relativeAddress = (uint) relativeOffset / 4;
+      return 0x94000000 | (relativeAddress & 0x3ffffff);
+    }
+  }
+}
+#endif

--- a/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/RtdxRom.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/RtdxRom.cs
@@ -128,13 +128,18 @@ namespace SkyEditor.RomEditor.Domain.Rtdx
         {
             if (mainExecutable == null)
             {
-                mainExecutable = MainExecutable.LoadFromNso(FileSystem.ReadAllBytes(GetNsoPath(this.RomDirectory)));
+                byte[] nso = FileSystem.ReadAllBytes(GetNsoPath(this.RomDirectory));
+                byte[] metadata = FileSystem.ReadAllBytes(GetIl2CppMetadataPath(this.RomDirectory));
+                mainExecutable = MainExecutable.LoadFromNso(nso, metadata);
             }
             return mainExecutable;
         }
         private IMainExecutable? mainExecutable;
 
         protected static string GetNsoPath(string directory) => Path.Combine(directory, "exefs", "main");
+
+        protected static string GetIl2CppMetadataPath(string directory) => Path.Combine(directory,
+            "romfs/Data/Managed/Metadata/global-metadata.dat");
         #endregion
 
         #region StreamingAssets/data

--- a/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/Executable/MainExecutable.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/Executable/MainExecutable.cs
@@ -1,125 +1,305 @@
 ﻿using NsoElfConverterDotNet;
 using SkyEditor.RomEditor.Domain.Rtdx.Constants;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.IO;
+using BindingFlags = System.Reflection.BindingFlags;
+#if !NETSTANDARD2_0
+using Il2CppInspector;
+using Il2CppInspector.Reflection;
+using Il2CppInspector.Model;
+#endif
 
 namespace SkyEditor.RomEditor.Domain.Rtdx.Structures.Executable
 {
-    public interface IMainExecutable
-    {
-        IReadOnlyList<StarterFixedPokemonMap> StarterFixedPokemonMaps { get; }
-        PegasusActDatabase ActorDatabase { get; }
-        public ExecutableVersion Version { get; }
-        public byte[] Data { get; set; }
+  public interface IMainExecutable
+  {
+    IReadOnlyList<StarterFixedPokemonMap> StarterFixedPokemonMaps { get; }
+    PegasusActDatabase ActorDatabase { get; }
+    public ExecutableVersion Version { get; }
+    public byte[] Data { get; set; }
 
-        byte[] ToElf();
-        byte[] ToNso(INsoElfConverter? nsoElfConverter = null);
+    byte[] ToElf();
+    byte[] ToNso(INsoElfConverter? nsoElfConverter = null);
+
+#if !NETSTANDARD2_0
+    public AppModel IlAppModel { get; }
+    public Dictionary<string, ulong> SectionOffsets { get; }
+
+    /// <summary>Retrieve the offset of a method relative to the start of the code ELF segment.</summary>
+    ulong GetIlMethodOffset(string fullTypeName, string methodName, string[] paramTypeNames);
+
+    /// <summary>Retrieve the offset of a constructor relative to the start of the code ELF segment.</summary>
+    ulong GetIlConstructorOffset(string fullTypeName, string[] paramTypeNames);
+#endif
+  }
+
+  public class MainExecutable : IMainExecutable
+  {
+    public static MainExecutable LoadFromNso(byte[] file, byte[] il2CppMetadata, INsoElfConverter? nsoElfConverter = null)
+    {
+      nsoElfConverter ??= NsoElfConverter.Instance;
+      var data = nsoElfConverter.ConvertNsoToElf(file);
+      return new MainExecutable(data, il2CppMetadata);
     }
 
-    public class MainExecutable : IMainExecutable
+    public MainExecutable(byte[] elfData, byte[] il2CppMetadata)
     {
-        public static MainExecutable LoadFromNso(byte[] file, INsoElfConverter? nsoElfConverter = null)
-        {
-            nsoElfConverter ??= NsoElfConverter.Instance;
-            var data = nsoElfConverter.ConvertNsoToElf(file);
-            return new MainExecutable(data);
-        }
+      if (elfData == null)
+      {
+        throw new ArgumentNullException(nameof(elfData));
+      }
+      if (elfData.Length <= (0x04BA3B0C + 0x90))
+      {
+        throw new ArgumentException("Data is not long enough to contain known sections", nameof(elfData));
+      }
 
-        public MainExecutable(byte[] elfData)
-        {
-            if (elfData == null)
-            {
-                throw new ArgumentNullException(nameof(elfData));
-            }
-            if (elfData.Length <= (0x04BA3B0C + 0x90))
-            {
-                throw new ArgumentException("Data is not long enough to contain known sections", nameof(elfData));
-            }
+      this.Data = elfData ?? throw new ArgumentNullException(nameof(elfData));
+      this.Il2CppMetadata = il2CppMetadata ?? throw new ArgumentNullException(nameof(il2CppMetadata));
 
-            this.Data = elfData ?? throw new ArgumentNullException(nameof(elfData));
-
-            Init();
-            
-            ActDatabaseLazy = new Lazy<PegasusActDatabase>(() => new PegasusActDatabase(elfData, Version));
-        }
-
-        const int starterFixedPokemonMapOffsetOriginal = 0x04BA3B0C;
-        const int starterFixedPokemonMapOffsetUpdate = 0x04BA4DBC;
-
-        private void Init()
-        {
-            Init(starterFixedPokemonMapOffsetOriginal);
-            if (StarterFixedPokemonMaps.All(m => m.PokemonId == CreatureIndex.NONE))
-            {
-                Init(starterFixedPokemonMapOffsetUpdate);
-                Version = ExecutableVersion.Update1;
-            }
-            else
-            {
-                Version = ExecutableVersion.Original;
-            }
-        }
-
-        private void Init(int starterFixedPokemonMapOffset)
-        {
-            var starterFixedPokemonMaps = new List<StarterFixedPokemonMap>();
-            for (int i = 0; i < 16; i++)
-            {
-                var offset = starterFixedPokemonMapOffset + (8 * i);
-                starterFixedPokemonMaps.Add(new StarterFixedPokemonMap
-                {
-                    PokemonId = (CreatureIndex)BitConverter.ToInt32(Data, offset),
-                    FixedPokemonId = (FixedCreatureIndex)BitConverter.ToInt32(Data, offset + 4)
-                });
-            }
-            this.StarterFixedPokemonMaps = starterFixedPokemonMaps;
-        }
-
-        public byte[] ToElf()
-        {
-            if (ActDatabaseLazy.IsValueCreated) // No need to write if we haven't even accessed it
-            {
-                ActorDatabase.Write();
-            }
-
-            int starterFixedPokemonMapOffset = Version switch
-            {
-                ExecutableVersion.Original => starterFixedPokemonMapOffsetOriginal,
-                ExecutableVersion.Update1 => starterFixedPokemonMapOffsetUpdate,
-                _ => throw new InvalidOperationException("Unsupported executable version")
-            };
-
-            for (int i = 0; i < 16; i++)
-            {
-                var map = StarterFixedPokemonMaps[i];
-                var offset = starterFixedPokemonMapOffset + (8 * i);
-                BitConverter.GetBytes((int)map.PokemonId).CopyTo(Data, offset);
-                BitConverter.GetBytes((int)map.FixedPokemonId).CopyTo(Data, offset + 4);
-            }
-            return this.Data;
-        }
-
-        public byte[] ToNso(INsoElfConverter? nsoElfConverter = null)
-        {
-            nsoElfConverter ??= NsoElfConverter.Instance;
-            return nsoElfConverter.ConvertElfToNso(ToElf());
-        }
-        
-        public byte[] Data { get; set; }
-        public ExecutableVersion Version { get; private set; }
-
-        public IReadOnlyList<StarterFixedPokemonMap> StarterFixedPokemonMaps { get; private set; } = default!;
-        
-        private Lazy<PegasusActDatabase> ActDatabaseLazy { get; }
-        public PegasusActDatabase ActorDatabase => ActDatabaseLazy.Value;
+      Init();
     }
 
-    [DebuggerDisplay("StarterFixedPokemonMap: {PokemonId} -> {FixedPokemonId}")]
-    public class StarterFixedPokemonMap
+    const int starterFixedPokemonMapOffsetOriginal = 0x04BA3B0C;
+    const int starterFixedPokemonMapOffsetUpdate = 0x04BA4DBC;
+
+    private void Init()
     {
-        public CreatureIndex PokemonId { get; set; }
-        public FixedCreatureIndex FixedPokemonId { get; set; }
+      Init(starterFixedPokemonMapOffsetOriginal);
+      if (StarterFixedPokemonMaps.All(m => m.PokemonId == CreatureIndex.NONE))
+      {
+        Init(starterFixedPokemonMapOffsetUpdate);
+        Version = ExecutableVersion.Update1;
+      }
+      else
+      {
+        Version = ExecutableVersion.Original;
+      }
     }
+
+    private void Init(int starterFixedPokemonMapOffset)
+    {
+      var starterFixedPokemonMaps = new List<StarterFixedPokemonMap>();
+      for (int i = 0; i < 16; i++)
+      {
+        var offset = starterFixedPokemonMapOffset + (8 * i);
+        starterFixedPokemonMaps.Add(new StarterFixedPokemonMap
+        {
+          PokemonId = (CreatureIndex)BitConverter.ToInt32(Data, offset),
+          FixedPokemonId = (FixedCreatureIndex)BitConverter.ToInt32(Data, offset + 4)
+        });
+      }
+      this.StarterFixedPokemonMaps = starterFixedPokemonMaps;
+    }
+
+    public byte[] ToElf()
+    {
+      if (actorDatabase != null) // No need to write if we haven't even accessed it
+      {
+        ActorDatabase.Write();
+      }
+
+      int starterFixedPokemonMapOffset = Version switch
+      {
+        ExecutableVersion.Original => starterFixedPokemonMapOffsetOriginal,
+        ExecutableVersion.Update1 => starterFixedPokemonMapOffsetUpdate,
+        _ => throw new InvalidOperationException("Unsupported executable version")
+      };
+
+      for (int i = 0; i < 16; i++)
+      {
+        var map = StarterFixedPokemonMaps[i];
+        var offset = starterFixedPokemonMapOffset + (8 * i);
+        BitConverter.GetBytes((int)map.PokemonId).CopyTo(Data, offset);
+        BitConverter.GetBytes((int)map.FixedPokemonId).CopyTo(Data, offset + 4);
+      }
+      return Data;
+    }
+
+    public byte[] ToNso(INsoElfConverter? nsoElfConverter = null)
+    {
+      nsoElfConverter ??= NsoElfConverter.Instance;
+      return nsoElfConverter.ConvertElfToNso(ToElf());
+    }
+
+    public byte[] Data { get; set; }
+    public byte[] Il2CppMetadata { get; }
+    public ExecutableVersion Version { get; private set; }
+
+    public IReadOnlyList<StarterFixedPokemonMap> StarterFixedPokemonMaps { get; private set; } = default!;
+
+    private PegasusActDatabase? actorDatabase;
+    public PegasusActDatabase ActorDatabase
+    {
+      get
+      {
+        if (actorDatabase == null)
+        {
+          actorDatabase = new PegasusActDatabase(this);
+        }
+        return actorDatabase;
+      }
+    }
+
+#if !NETSTANDARD2_0
+    private Dictionary<string, ulong>? sectionOffsets;
+
+    public Dictionary<string, ulong> SectionOffsets
+    {
+      get
+      {
+        if (sectionOffsets == null)
+        {
+          LoadIlAppModel();
+        }
+        return sectionOffsets!;
+      }
+    }
+
+    private AppModel? ilAppModel;
+
+    public AppModel IlAppModel
+    {
+      get
+      {
+        {
+          if (ilAppModel == null)
+          {
+            LoadIlAppModel();
+          }
+          return ilAppModel!;
+        }
+      }
+    }
+
+    private void LoadIlAppModel()
+    {
+      // Lazily create an Il2CppInspector model. Copying the ELF data array is required since the library
+      // seems to mess with the data, which crashes the game.
+      // TODO: Consider caching the result in a file. This is horribly slow.
+      var binaryStream = new MemoryStream(Data.ToArray());
+      var metadataStream = new MemoryStream(Il2CppMetadata);
+
+      var oldOut = Console.Out;
+      // Disable Console.WriteLine() since Il2CppInspector logs text
+      Console.SetOut(TextWriter.Null);
+
+      try
+      {
+        // The internal class Il2CppInspector.ElfReader64 can be used to retrieve the offsets of sections
+        // in the ELF file. These are relevant since Il2CppInspector saves symbol offsets relative to the
+        // code section of the ELF so this offset needs to be considered when editing the ELF.
+        var elfReader = CreateAndInitElfReader(binaryStream);
+        ReadSectionOffsets(elfReader);
+
+        // Create the inspector manually instead of using Il2CppInspector.LoadFromStream to avoid
+        // reading the ELF a second time.
+        var metadata = new Metadata(metadataStream);
+        var binary = Il2CppBinary.Load(elfReader, metadata);
+        var inspector = new Il2CppInspector.Il2CppInspector(binary, metadata);
+
+        if (inspector == null)
+        {
+          throw new Exception("Couldn't extract Il2Cpp metadata.");
+        }
+
+        ilAppModel = new AppModel(new TypeModel(inspector));
+      }
+      finally
+      {
+        Console.SetOut(oldOut);
+      }
+    }
+
+    public ulong GetIlMethodOffset(string fullTypeName, string methodName, string[] paramTypeNames)
+    {
+      var methodInfos = GetIlType(fullTypeName).GetMethods(methodName);
+      var overloadMethodInfo = FindMethodOverload(methodInfos, paramTypeNames);
+      if (overloadMethodInfo == null)
+      {
+        throw new ArgumentException("The method doesn't exist.");
+      }
+      return IlAppModel.Methods[overloadMethodInfo].MethodCodeAddress;
+    }
+
+    public ulong GetIlConstructorOffset(string fullTypeName, string[] paramTypeNames)
+    {
+      var methodInfos = GetIlType(fullTypeName).DeclaredConstructors.ToArray();
+      var overloadMethodInfo = FindMethodOverload(methodInfos, paramTypeNames);
+      if (overloadMethodInfo == null)
+      {
+        throw new ArgumentException("The constructor doesn't exist.");
+      }
+      return IlAppModel.Methods[overloadMethodInfo].MethodCodeAddress;
+    }
+
+    private IFileFormatReader CreateAndInitElfReader(Stream binaryStream)
+    {
+      var elfReaderType = typeof(Il2CppInspector.Il2CppInspector).Assembly.GetType("Il2CppInspector.ElfReader64");
+      var elfReader = (IFileFormatReader)Activator.CreateInstance(elfReaderType, binaryStream);
+      elfReaderType.BaseType.GetMethod("Init", BindingFlags.Instance | BindingFlags.NonPublic)
+        .Invoke(elfReader, new object[] { });
+      return elfReader;
+    }
+
+    private void ReadSectionOffsets(IFileFormatReader elfReader)
+    {
+      var sectionByName = (IDictionary)elfReader.GetType().BaseType.GetField("sectionByName", BindingFlags.Instance
+        | BindingFlags.NonPublic).GetValue(elfReader);
+
+      sectionOffsets = new Dictionary<string, ulong>();
+      foreach (DictionaryEntry sectionKeyValue in sectionByName)
+      {
+        var value = sectionKeyValue.Value;
+        ulong offset = (ulong)value.GetType().GetField("sh_offset").GetValue(value);
+        sectionOffsets.Add((string)sectionKeyValue.Key, offset);
+      }
+    }
+
+    private TypeInfo GetIlType(string fullTypeName)
+    {
+      if (!fullTypeName.Contains("."))
+      {
+        // Types without a namespace should still start with "."
+        fullTypeName = '.' + fullTypeName;
+      }
+      return IlAppModel.TypeModel.GetType(fullTypeName);
+    }
+
+    private MethodBase? FindMethodOverload(MethodBase[] methodInfos, string[] paramTypeNames)
+    {
+      var paramTypes = paramTypeNames.Select(GetIlType).ToArray();
+      for (int i = 0; i < methodInfos.Length; i++)
+      {
+        var methodInfo = methodInfos[i];
+        bool isPossibleCandidate = methodInfo.DeclaredParameters.Count == paramTypeNames.Length;
+        for (int j = 0; j < methodInfo.DeclaredParameters.Count && isPossibleCandidate; j++)
+        {
+          if (paramTypes[j] != methodInfo.DeclaredParameters[j].ParameterType)
+          {
+            isPossibleCandidate = false;
+          }
+        }
+
+        if (isPossibleCandidate)
+        {
+          return methodInfo;
+        }
+      }
+
+      return null;
+    }
+
+#endif
+  }
+
+  [DebuggerDisplay("StarterFixedPokemonMap: {PokemonId} -> {FixedPokemonId}")]
+  public class StarterFixedPokemonMap
+  {
+    public CreatureIndex PokemonId { get; set; }
+    public FixedCreatureIndex FixedPokemonId { get; set; }
+  }
 }

--- a/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/Executable/PegasusActDatabase.ActorData.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Rtdx/Structures/Executable/PegasusActDatabase.ActorData.cs
@@ -14,7 +14,7 @@ namespace SkyEditor.RomEditor.Domain.Rtdx.Structures.Executable
             public PokemonFixedWarehouseId WarehouseId { get; set; } = default!;
             public TextIDHash SpecialName { get; set; } = default!;
             public string? DebugName { get; set; }
-            public int PokemonIndexOffset { get; set; }
+            public ulong PokemonIndexOffset { get; set; }
             public bool PokemonIndexEditable { get; set; }
         }
     }

--- a/SkyEditor.RomEditor.Rtdx/SkyEditor.RomEditor.csproj
+++ b/SkyEditor.RomEditor.Rtdx/SkyEditor.RomEditor.csproj
@@ -23,6 +23,10 @@
     <PackageReference Include="SkyEditor.IO" Version="5.1.16" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.1'">
+    <PackageReference Include="NoisyCowStudios.Il2CppInspector" Version="2020.2.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>


### PR DESCRIPTION
Integrates Il2CppInspector into SkyEditor to allow retrieving offsets of Il2Cpp symbols like C# methods from the ELF-converted binary. This enables creating code patches that are mostly independent of the game version. It should also help make patches more readable and may allow more advanced edits in the future.
